### PR TITLE
Fix typos and grammar-os in WildAgile article

### DIFF
--- a/root/wildagile.tt
+++ b/root/wildagile.tt
@@ -12,7 +12,7 @@ like this:</p>
 
 <p>Me: Ah! Do you use Scrum, XP, something else?</p>
 
-<p>Them (embarassed): Um, er, we just sort of get things
+<p>Them (embarrassed): Um, er, we just sort of get things
 done.</p></blockquote>
 
 <p>And they do! And yet they're embarrassed by the lack of a name for what they
@@ -134,7 +134,7 @@ a positive-feedback loop is created which allows the team to rapidly build and
 improve upon products. Any obstacles to these three requirements being met are
 detrimental to the productivity of any WildAgile-compliant team.</p>
 
-<p>I are also firm believers in the Pareto Rule: 80% of your benefits will
+<p>I am also a firm believer in the Pareto Rule: 80% of your benefits will
 stem from 20% of your actions. WildAgile attempts to implement that 20% of
 actions that give you majority of benefits of Agile. In fact, I've found that
 for many smaller teams, attempting to implement the other 80% of actions may
@@ -308,7 +308,7 @@ and ask. That doesn't work with remote workers. Instead, you simply extend the
 stand up time. I recommend 30 to 45 minutes. Yes, this means you'll be
 spending more time in the stand up, but you can communicate more about what
 you're doing, and how you are doing it. This helps to catch problems early on
-and minimes the need for developer to distract other developers while they're
+and minimizes the need for developers to distract other developers while they're
 working.</p>
 
 <h3>But what if the devs slack off?!</h3>
@@ -357,7 +357,7 @@ required to keep things in check.</p>
 
 <p>Also, WildAgile benefits from skilled, conscientious developers. It's very
 easy to spend too much time "perfecting" your code, but it's also easy to spend
-to much time pushing out new features and ignoring technical debt. This is a
+too much time pushing out new features and ignoring technical debt. This is a
 hard balance to maintain. WildAgile does not address this directly because
 every project is different and every company is different. However, as a
 guideline WildAgile suggests that the PO advocate for features and the Team


### PR DESCRIPTION
Hi @Ovid!  I stumbled across your WildAgile article and while reading it I noticed some typos and grammatical errors; I couldn't help myself and had to fix them :-)