### PR TITLE
Fix typos in Alan Kay missing messages article

### DIFF
--- a/root/articles/alan-kay-and-missing-messages-a-follow-up.tt
+++ b/root/articles/alan-kay-and-missing-messages-a-follow-up.tt
@@ -9,7 +9,7 @@
 
 <p>[% Ovid.link('/articles/alan-kay-and-oo-programming.html', "My discussion
 of Alan Kay's ideas behind OO programming") %] made the rounds, getting about
-13,000 pages views (as of this writing) from various sources, including [%
+13,000 page views (as of this writing) from various sources, including [%
 Ovid.cite('https://news.ycombinator.com/item?id=19968496#19969047', 'Hacker
 News' ) %] and [%
 Ovid.cite('https://www.reddit.com/r/programming/comments/bqu8td/a_simple_explanation_of_what_alan_kay_meant_when/',
@@ -82,8 +82,8 @@ of brilliance because he deeply understood the problem space.</p>
 
 <p>The ETL system was a bottleneck for this startup and honestly, no one
 wanted to touch it. A new dataset would arrive from a pharmaceutical company
-and it would take two days manual effort from a programmer to get the dataset
-into shape where it could be run through the "ETL" system. I say "ETL" in
+and it would take two days of manual effort from a programmer to get the dataset
+into a shape where it could be run through the "ETL" system. I say "ETL" in
 scare quotes because obviously you don't want to take a highly-paid software
 developer off of their work for several days of manual data cleanup just so
 you can process an Excel document. But this work was critical to the startup


### PR DESCRIPTION
Found a couple of typos in the new article and fixed them in this patch.