### PR TITLE
Fix typos in "The future of Perl" post

### DIFF
--- a/root/articles/the-future-of-perl.tt2markdown
+++ b/root/articles/the-future-of-perl.tt2markdown
@@ -31,7 +31,7 @@ great](/blog/politics-in-programming.html). (As an aside, it also doesn't quite
 appear to match my previous descriptions of it. Oops).
 
 With my initial commit of that code on September 2, 2018, the Corinna project
-has been roughly four and a halt years from conception to the initial core
+has been roughly four and a half years from conception to the initial core
 implementation.  Since that time, I worked on design, made an initial
 announcement, and led a design team of some of the top experts in Perl, with
 much feedback coming from others who've designed object systems such as Moose or
@@ -177,7 +177,7 @@ expression engine, [widely considered the best in the programming
 world](https://en.wikipedia.org/wiki/Perl_Compatible_Regular_Expressions).
 
 There's much more, but many issues are very Perl-specific and even many Perl
-programmers are not aware of the work done by of the porters.  The Perl 5.36.0
+programmers are not aware of the work done by the porters.  The Perl 5.36.0
 release alone represents approximately a year of development since Perl 5.34.0
 and contains approximately 250,000 lines of changes across 2,000 files from 82
 authors (taken from the `perldelta` file for 5.36.0).
@@ -226,7 +226,7 @@ It will simply make it easier to write Perl, but not offer much "new" to current
 developers, beyond a message to the programming world.
 
 For technical and political reasons,[% Ovid.add_note("'Politics' is not a dirty
-word. It's merely the art of getting concensus in a group.") %] Perl 7 without
+word. It's merely the art of getting consensus in a group.") %] Perl 7 without
 Corinna might be exactly what Perl needs. But even then, Perl 7 will be a far
 cry from the Perl released back in 1994. Perl's been evolving rapidly over the
 years, but without people hearing about it.
@@ -300,7 +300,7 @@ There are serious problems this solves, including:
 2. Don't wait on code that might block due to external resource constraints.
 
 P5P has long preferred that new ideas for Perl be tested on the CPAN before
-incorporating these ideas into the core. This allows us to see what is an isn't
+incorporating these ideas into the core. This allows us to see what is and isn't
 working (or in some cases, just to better understand the syntax people prefer).
 There are multiple attempts to solve the concurrency issue on the CPAN and given
 that this feature is being used more and more, and becoming a default feature in


### PR DESCRIPTION
While reading through this article I noticed a couple of typos that I thought you'd like fixed.

BTW: I'd have used:

> To sleep–perchance to dream–ay, there's the sub()

but that's just me :wink: 