### PR TITLE
Remove superfluous verb

### DIFF
--- a/articles/tracking-elon-musks-plane-with-perl.html
+++ b/articles/tracking-elon-musks-plane-with-perl.html
@@ -291,7 +291,7 @@ data and that’s shown in the script above. However, it’s not very useful. I
 wanted to see the actual airport names and times (the times returned by the API
 are <a href="https://en.wikipedia.org/wiki/Unix_time" target="_blank">Unix epochs</a> <span class="fa fa-external-link fa_custom"></span>).</p>
 
-<p>Getting the ICAO codes for the airports is was a bit harder. Since I’m doing
+<p>Getting the ICAO codes for the airports was a bit harder. Since I’m doing
 this open source, I eventually tracked down <a href="https://github.com/mborsetti/airportsdata" target="_blank">a fairly active GitHub repository
 with airport data</a> <span class="fa fa-external-link fa_custom"></span>. I wanted to use
 the <a href="https://metacpan.org/pod/Geo::ICAO" target="_blank">Geo::ICAO</a> <span class="fa fa-external-link fa_custom"></span> module to convert the ICAO

--- a/root/articles/tracking-elon-musks-plane-with-perl.tt2markdown
+++ b/root/articles/tracking-elon-musks-plane-with-perl.tt2markdown
@@ -97,7 +97,7 @@ data and that's shown in the script above. However, it's not very useful. I
 wanted to see the actual airport names and times (the times returned by the API
 are [Unix epochs](https://en.wikipedia.org/wiki/Unix_time)).
 
-Getting the ICAO codes for the airports is was a bit harder. Since I'm doing
+Getting the ICAO codes for the airports was a bit harder. Since I'm doing
 this open source, I eventually tracked down [a fairly active GitHub repository
 with airport data](https://github.com/mborsetti/airportsdata). I wanted to use
 the [Geo::ICAO](https://metacpan.org/pod/Geo::ICAO) module to convert the ICAO


### PR DESCRIPTION
I'm pretty sure you meant this sentence to be in the past tense, hence I chose to keep 'was' here and removed the extra word 'is'.